### PR TITLE
fix: 解密回执报错

### DIFF
--- a/lib/InvoiceClient.js
+++ b/lib/InvoiceClient.js
@@ -157,9 +157,12 @@ class InvoiceClient {
       explicitArray: false,
     });
 
-    const { dataDescription, content} = body.interface.Data;
+    const { passWord } = body.interface.globalInfo;
+    const { dataDescription, content } = body.interface.Data;
+    const key = passWord.slice(-24);
+    const option = _.merge({}, dataDescription, {key: key});
 
-    return invoiceCore.decryptByOption(content, dataDescription);
+    return invoiceCore.decryptByOption(content, option);
   }
 
   updateConfig(params) {

--- a/lib/InvoiceCore.js
+++ b/lib/InvoiceCore.js
@@ -9,7 +9,6 @@ class InvoiceCore {
     constructor(config) {
         this.config = config;
         this.instance = null;
-        this.des3Ede = new Crypto('des-ede3', config.KEY3DES);
     }
 
     static instance(...args) {
@@ -461,8 +460,9 @@ class InvoiceCore {
         return this.config;
     };
 
-    des3Encrypt(message, needGzip = false) {
-        let result = this.des3Ede.encrypt(message);
+    des3Encrypt(message, key = this.config.KEY3DES, needGzip = false) {
+        const cipher = new Crypto('des-ede3', key);
+        let result = cipher.encrypt(message);
         if (needGzip) {
             const gzipBuf = zlib.gzipSync(Buffer.from(result, 'base64'));
             result = gzipBuf.toString('base64');
@@ -471,27 +471,28 @@ class InvoiceCore {
         return result;
     };
 
-    des3Decrypt(encrypted, needUnGzip = false) {
+    des3Decrypt(encrypted, key = this.config.KEY3DES, needUnGzip = false) {
+        const cipher = new Crypto('des-ede3', key);
         let result;
         if (needUnGzip) {
             const bufRes = Buffer.from(encrypted, 'base64');
             const unzipRes = zlib.gunzipSync(bufRes);
-            result = this.des3Ede.decrypt(Buffer.from(unzipRes).toString('base64'));
+            result = cipher.decrypt(unzipRes);
         } else {
-            result = this.des3Ede.decrypt(encrypted);
+            result = cipher.decrypt(encrypted);
         }
 
         return result;
     };
 
-    async decryptByOption(content, { zipCode, encryptCode, codeType}) {
+    async decryptByOption(content, { key, zipCode, encryptCode, codeType}) {
         let result = content;
         // TODO 不支持CA
         if (zipCode === '1' && encryptCode === '1' && (codeType === '3DES' || codeType === '0')) {
-            result = await this.des3Decrypt(content, true)
+            result = await this.des3Decrypt(content, key, true)
         }
         if (zipCode === '0' && encryptCode === '1' && (codeType === '3DES' || codeType === '0')) {
-            result = await this.des3Decrypt(content)
+            result = await this.des3Decrypt(content, key)
         }
 
         const resultJson = await util.parseXML(result, {
@@ -500,10 +501,6 @@ class InvoiceCore {
         });
 
         return resultJson;
-    }
-
-    setKey3Des(key) {
-        this.des3Ede.setKey(key);
     }
 };
 

--- a/test/InvoiceCore.test.js
+++ b/test/InvoiceCore.test.js
@@ -44,7 +44,7 @@ describe.only('test/InvoiceCore.test.js', () => {
   });
 
   it('des3Encrypt needGzip=true', async () => {
-    const result = await invoiceCore.des3Encrypt('1', true);
+    const result = await invoiceCore.des3Encrypt('1', undefined, true);
     console.log(result);
     assert(result === 'H4sIAAAAAAAAE7tSk19vl7ImCwCMQGK+CAAAAA=='); // 不一定与网站测试工具一致
   });
@@ -55,10 +55,18 @@ describe.only('test/InvoiceCore.test.js', () => {
     assert(result === '1');
   });
 
-  it.only('des3Decrypt needUnGzip=true', async () => {
-    const result = await invoiceCore.des3Decrypt('H4sIAAAAAAAAALtSk19vl7ImCwCMQGK+CAAAAA==', true);
+  it('des3Decrypt needUnGzip=true', async () => {
+    const result = await invoiceCore.des3Decrypt('H4sIAAAAAAAAALtSk19vl7ImCwCMQGK+CAAAAA==', undefined, true);
     console.log(result);
     assert(result === '1');
+  });
+
+  it('des3Encrypt specify key needGzip=true', async () => {
+    const key = '123456789012345678901234';
+    const encrypted = await invoiceCore.des3Encrypt('100', key, true);
+    const result = await invoiceCore.des3Decrypt(encrypted, key, true);
+    console.log(result);
+    assert(result === '100');
   });
 
 });


### PR DESCRIPTION
- InvoiceCore 加解密支持指定key，使其解密回执时能指定其他key.  
- InvoiceClient#parseNotificationResult 使用KEY3DES解密回执报错  